### PR TITLE
Performance improvements

### DIFF
--- a/bad_words/lib/bad_words.dart
+++ b/bad_words/lib/bad_words.dart
@@ -15,7 +15,7 @@ class Filter {
     final listToTest = stringToObfuscate.split(' ');
     final clean = listToTest.map((e) {
       if (wordSet.contains(e.toLowerCase())) {
-        return e.replaceAll(RegExp('.'), '*');
+        return ''.padLeft(e.length, '*');
       }
       return e;
     });

--- a/bad_words/lib/bad_words.dart
+++ b/bad_words/lib/bad_words.dart
@@ -7,14 +7,14 @@ class Filter {
   /// isProfane returns a boolean value representing if the string provided contains a profane word
   bool isProfane(String stringToTest) {
     final lowerCaseStringToTest = stringToTest.toLowerCase();
-    return wordList.any((word) => lowerCaseStringToTest.contains(word));
+    return badwords.any((word) => lowerCaseStringToTest.contains(word));
   }
 
   /// replace tests a string, replacing bad words with an asterisk length string of equal length
   String clean(String stringToObfuscate) {
     final listToTest = stringToObfuscate.split(' ');
     final clean = listToTest.map((e) {
-      if (wordSet.contains(e.toLowerCase())) {
+      if (badwords.contains(e.toLowerCase())) {
         return ''.padLeft(e.length, '*');
       }
       return e;

--- a/bad_words/lib/bad_words.dart
+++ b/bad_words/lib/bad_words.dart
@@ -7,9 +7,7 @@ class Filter {
   /// isProfane returns a boolean value representing if the string provided contains a profane word
   bool isProfane(String stringToTest) {
     final lowerCaseStringToTest = stringToTest.toLowerCase();
-    return wordList
-        .where((word) => lowerCaseStringToTest.contains(word))
-        .isNotEmpty;
+    return wordList.any((word) => lowerCaseStringToTest.contains(word));
   }
 
   /// replace tests a string, replacing bad words with an asterisk length string of equal length

--- a/bad_words/lib/word_list.dart
+++ b/bad_words/lib/word_list.dart
@@ -1,5 +1,5 @@
-/// wordList is the array of bad word strings inspired by the `bad-words` javascript package
-const wordList = <String>[
+/// badwords is a set of bad word strings inspired by the `bad-words` javascript package
+const badwords = <String>{
   "4r5e",
   "5h1t",
   "5hit",
@@ -471,19 +471,14 @@ const wordList = <String>[
   "bastardz",
   "basterds",
   "basterdz",
-  "biatch",
-  "blow job",
   "boffing",
   "buttwipe",
   "c0cks",
   "c0k",
-  "carpet muncher",
   "cawks",
-  "clit",
   "cnts",
   "cntz",
   "cock-head",
-  "cocksucker",
   "cuntz",
   "dild0",
   "dild0s",
@@ -504,17 +499,13 @@ const wordList = <String>[
   "faigs",
   "fart",
   "flipping the bird",
-  "fudge packer",
   "fukah",
   "fuken",
   "fukin",
   "fukk",
   "fukkah",
   "fukken",
-  "fukker",
-  "fukkin",
   "g00k",
-  "god-damned",
   "h00r",
   "h0ar",
   "h0re",
@@ -542,7 +533,6 @@ const wordList = <String>[
   "motha fuker",
   "motha fukkah",
   "motha fukker",
-  "mother fucker",
   "mother fukah",
   "mother fuker",
   "mother fukkah",
@@ -582,8 +572,6 @@ const wordList = <String>[
   "penus",
   "penuus",
   "phuc",
-  "phuck",
-  "phuk",
   "phuker",
   "phukker",
   "polac",
@@ -610,7 +598,6 @@ const wordList = <String>[
   "sh1ts",
   "sh1tter",
   "sh1tz",
-  "shitty",
   "shity",
   "shitz",
   "shyt",
@@ -731,7 +718,4 @@ const wordList = <String>[
   "🔪",
   "🔫",
   "💩"
-];
-
-/// wordSet is the list of bad words as a set for quicker
-final wordSet = Set.from(wordList);
+};


### PR DESCRIPTION
A bundle of a few minor performance improvements:

- Improves the performance of the `isProfane` method by returning true after any bad word is found, rather than matching all bad words in the string.
- Improves performance of `clean` by 56x by replacing use of `e.replaceAll(RegExp('.'), '*')` with `''.padLeft(e.length, '*')`.
- Uses a set literal rather than list literal for the bad words.

See commit messages for more detail.