### PR TITLE
Make Filter methods static to avoid the need for instantiation

### DIFF
--- a/bad_words/README.md
+++ b/bad_words/README.md
@@ -13,12 +13,10 @@ bad_words: ^0.2.2
 ```dart
 import 'package:bad_words/bad_words.dart';
 
-final filter = Filter();
-
-if (filter.isProfane('some string to test')) {
+if (Filter.isProfane('some string to test')) {
     // ... validation error etc.
 }
 
 // clean up a profane string
-final cleanString = filter.clean('some test string');
+final cleanString = Filter.clean('some test string');
 ```

--- a/bad_words/example/example.dart
+++ b/bad_words/example/example.dart
@@ -2,14 +2,13 @@ import 'package:bad_words/bad_words.dart';
 
 main() {
   final testString = 'string that does not contain bad words';
-  final filter = Filter();
 
   // check if the string is profane
-  if (filter.isProfane(testString)) {
+  if (Filter.isProfane(testString)) {
     print('put a nickle in the swear jar!');
   }
 
   // clean up those bad words
-  final clean = filter.clean(testString);
+  final clean = Filter.clean(testString);
   return clean;
 }

--- a/bad_words/lib/bad_words.dart
+++ b/bad_words/lib/bad_words.dart
@@ -5,7 +5,7 @@ import 'word_list.dart';
 /// Bad Word Filter
 class Filter {
   /// isProfane returns a boolean value representing if the string provided contains a profane word
-  bool isProfane(String stringToTest) {
+  static bool isProfane(String stringToTest) {
     final lowerCaseStringToTest = stringToTest.toLowerCase();
     return wordList
         .where((word) => lowerCaseStringToTest.contains(word))
@@ -13,7 +13,7 @@ class Filter {
   }
 
   /// replace tests a string, replacing bad words with an asterisk length string of equal length
-  String clean(String stringToObfuscate) {
+  static String clean(String stringToObfuscate) {
     final listToTest = stringToObfuscate.split(' ');
     final clean = listToTest.map((e) {
       if (wordSet.contains(e.toLowerCase())) {

--- a/bad_words/test/bad_words_test.dart
+++ b/bad_words/test/bad_words_test.dart
@@ -3,26 +3,24 @@ import 'package:bad_words/bad_words.dart';
 
 void main() {
   test('tests isProfane method', () {
-    final filter = Filter();
-    expect(filter.isProfane('wholesome text'), false);
-    expect(filter.isProfane("All of the Dodgers can eat a 🍆"), true);
-    expect(filter.isProfane("Fuck the Dodgers"), true);
-    expect(filter.isProfane('All Dodgers are nobheads'), true);
-    expect(filter.isProfane('The Dodgers are sh!t'), true);
-    expect(() => filter.isProfane(null), throwsNoSuchMethodError);
+    expect(Filter.isProfane('wholesome text'), false);
+    expect(Filter.isProfane("All of the Dodgers can eat a 🍆"), true);
+    expect(Filter.isProfane("Fuck the Dodgers"), true);
+    expect(Filter.isProfane('All Dodgers are nobheads'), true);
+    expect(Filter.isProfane('The Dodgers are sh!t'), true);
+    expect(() => Filter.isProfane(null), throwsNoSuchMethodError);
   });
 
   test('test clean method', () {
-    final filter = Filter();
     // clean string
-    expect(filter.clean('test string without asterisks'),
+    expect(Filter.clean('test string without asterisks'),
         'test string without asterisks');
     // beginning of the string
-    expect(filter.clean('fucking test string'), '******* test string');
+    expect(Filter.clean('fucking test string'), '******* test string');
     // end of the string
-    expect(filter.clean('All Dodgers are sh!t'), 'All Dodgers are ****');
+    expect(Filter.clean('All Dodgers are sh!t'), 'All Dodgers are ****');
     // test more than one bad word
-    expect(filter.clean('Those shitty Dodgers are arschloch'),
+    expect(Filter.clean('Those shitty Dodgers are arschloch'),
         'Those ****** Dodgers are *********');
   });
 }


### PR DESCRIPTION
Hi Tyler,

This PR is a little opinionated, and is a breaking change, so I'll understand if you'd rather not merge it. But I couldn't resist sending it your way.

The current library requires users to create a `Filter` object before they can use the `isProfane` or `clean` methods. But `Filter` has are no class variables, and there is no work performed by the `Filter` constructor. So there's no need or benefit from creating an instance of `Filter` before accessing those methods.

If we make the `isProfane` and `clean` methods static, users can call `isProfane` and `clean` without first instantiating `Filter`. I don't see any downside to this. Even if you plan to add configuration options in the future, you could handle those options much like `Logger` and `Logger.root` in `package:log/log.dart` — no need for instantiation.

Making these methods static is a breaking change, and would probably warrant a bump to version 0.3.0.

If existing users of the library upgrade, they would need to make some very minor changes. For example, they would replace this:

```dart
final filter = Filter();
filter.isProfane('a string');
final cleanString = filter.clean('a string');
```

with this:

```dart
Filter.isProfane('a string');
final cleanString = Filter.clean('a string');
```

Like I said, feel free to ignore this PR if you'd rather not make breaking changes. But I think this improves the ergonomics of the library hugely, so I am in favour. 👍 

Cheers,
Ben